### PR TITLE
OFS-283: Add missing translation

### DIFF
--- a/src/components/PaymentSearcher.js
+++ b/src/components/PaymentSearcher.js
@@ -138,7 +138,7 @@ class PaymentSearcher extends Component {
         ];
         if (this.props.rights.includes(RIGHT_PAYMENT_EDIT)) {
             formatters.push((p) => (
-                <Tooltip title={formatMessage(this.props.intl, "payment", "contribution.openNewTab")}>
+                <Tooltip title={formatMessage(this.props.intl, "payment", "openNewTab")}>
                     <IconButton onClick={() => this.props.onDoubleClick(p, true)}>
                         <TabIcon />
                     </IconButton>


### PR DESCRIPTION
Translation of tooltip of "open in new tab" button on Payments search page was missing. Therefore it was missing on Policy Holder and Contract pages as well. This PR fixes this issue.