### PR TITLE
OTC-757: Clearing pagination state if entered the PaymentsPage

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,5 +4,7 @@ export const RIGHT_PAYMENT_ADD = 101402
 export const RIGHT_PAYMENT_EDIT = 101403
 export const RIGHT_PAYMENT_DELETE = 101404
 
+export const MODULE_NAME = "payment";
+
 export const PAYMENT_STATUS = [-3, -2, -1, 1, 2, 3, 4, 5];
 export const PAYMENTS_TAB_VALUE = "paymentsTab"

--- a/src/pages/PaymentsPage.js
+++ b/src/pages/PaymentsPage.js
@@ -8,6 +8,7 @@ import {
   withHistory,
   clearCurrentPaginationPage,
 } from "@openimis/fe-core";
+import { MODULE_NAME } from "../constants";
 import PaymentSearcher from "../components/PaymentSearcher";
 
 const styles = theme => ({
@@ -21,9 +22,8 @@ class PaymentsPage extends Component {
     // }
 
     componentDidMount = () => {
-        const moduleName = "payment";
         const { module } = this.props;
-        if (module !== moduleName) this.props.clearCurrentPaginationPage();
+        if (module !== MODULE_NAME) this.props.clearCurrentPaginationPage();
       };
 
     render() {

--- a/src/pages/PaymentsPage.js
+++ b/src/pages/PaymentsPage.js
@@ -1,8 +1,13 @@
 import React, { Component } from "react";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
-import { injectIntl } from 'react-intl';
+import { injectIntl } from "react-intl";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { withModulesManager, withHistory } from "@openimis/fe-core"
+import {
+  withModulesManager,
+  withHistory,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import PaymentSearcher from "../components/PaymentSearcher";
 
 const styles = theme => ({
@@ -10,11 +15,16 @@ const styles = theme => ({
     fab: theme.fab
 });
 
-
 class PaymentsPage extends Component {
     // onAdd = () => {
     //     historyPush(this.props.modulesManager, this.props.history, "payment.paymentNew");
     // }
+
+    componentDidMount = () => {
+        const moduleName = "payment";
+        const { module } = this.props;
+        if (module !== moduleName) this.props.clearCurrentPaginationPage();
+      };
 
     render() {
         const { intl, classes, rights } = this.props;
@@ -40,8 +50,11 @@ class PaymentsPage extends Component {
 
 const mapStateToProps = state => ({
     rights: !!state.core && !!state.core.user && !!state.core.user.i_user ? state.core.user.i_user.rights : [],
+    module: state.core?.savedPagination?.module,
 })
 
+const mapDispatchToProps = (dispatch) => bindActionCreators({ clearCurrentPaginationPage }, dispatch);
+
 export default injectIntl(withModulesManager(
-    withHistory(connect(mapStateToProps)(withTheme(withStyles(styles)(PaymentsPage))))
+    withHistory(connect(mapStateToProps, mapDispatchToProps)(withTheme(withStyles(styles)(PaymentsPage))))
 ));


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:

- Clearing pagination state if entered the PaymentsPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ