### PR TITLE
OP-1725: remove null empty option from dropdown

### DIFF
--- a/src/components/PaymentMasterPanel.js
+++ b/src/components/PaymentMasterPanel.js
@@ -100,7 +100,7 @@ class PaymentMasterPanel extends FormPanel {
                     <Grid item xs={3} className={classes.item}>
                         <PublishedComponent
                             pubRef="contribution.PremiumPaymentTypePicker"
-                            withNull={true}
+                            withNull={false}
                             required
                             readOnly={readOnly}
                             value={!edited ? "" : edited.typeOfPayment}
@@ -119,7 +119,7 @@ class PaymentMasterPanel extends FormPanel {
                     <Grid item xs={3} className={classes.item}>
                         <PublishedComponent
                             pubRef="payment.PaymentStatusPicker"
-                            withNull={true}
+                            withNull={false}
                             readOnly={readOnly}
                             value={!edited ? "" : edited.status}
                             onChange={p => this.updateAttribute('status', p)}


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:

- Remove the 'none/null' option from the dropdowns menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ